### PR TITLE
SchemaAwareJsonDataProvider improvements

### DIFF
--- a/combit.ListLabel.SchemaAwareJsonDataProvider/JsonSchemaTable/JsonSchemaOnlyTableRow.cs
+++ b/combit.ListLabel.SchemaAwareJsonDataProvider/JsonSchemaTable/JsonSchemaOnlyTableRow.cs
@@ -1,7 +1,7 @@
-﻿using System;
+﻿using NJsonSchema;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using NJsonSchema;
 
 namespace combit.Reporting.DataProviders
 {
@@ -33,31 +33,34 @@ namespace combit.Reporting.DataProviders
                 return new JsonTableColumn(columnName, typeof(string), LlConstants.NullValue);
             }
 
-            if (data.Type == JsonObjectType.Boolean)
+            bool isNullable = !data.IsRequired;
+
+            if (data.Type.HasFlag(JsonObjectType.Boolean))
             {
-                return new JsonTableColumn(columnName, typeof(bool), null);
+                return new JsonTableColumn(columnName, isNullable ? typeof(bool?) : typeof(bool), null);
             }
 
             //https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3.1
-            if (data.Type == JsonObjectType.String && (data.Format == "date-time" || data.Format == "date" || data.Format == "time"))
+            if (data.Type.HasFlag(JsonObjectType.String) && (data.Format == "date-time" || data.Format == "date" || data.Format == "time"))
             {
-                return new JsonTableColumn(columnName, typeof(DateTime), null);
+                return new JsonTableColumn(columnName, isNullable ? typeof(DateTime?) : typeof(DateTime), null);
             }
 
-            if (data.Type == JsonObjectType.String)
+            if (data.Type.HasFlag(JsonObjectType.String))
+
             {
                 return new JsonTableColumn(columnName, typeof(string), LlConstants.NullValue);
             }
 
             //An arbitrary-precision, base-10 decimal number value, from the JSON "number" value
-            if (data.Type == JsonObjectType.Number)
+            if (data.Type.HasFlag(JsonObjectType.Number))
             {
-                return new JsonTableColumn(columnName, typeof(double), null);
+                return new JsonTableColumn(columnName, isNullable ? typeof(double?) : typeof(double), null);
             }
 
-            if (data.Type == JsonObjectType.Integer)
+            if (data.Type.HasFlag(JsonObjectType.Integer))
             {
-                return new JsonTableColumn(columnName, typeof(int), null);
+                return new JsonTableColumn(columnName, isNullable ? typeof(int?) : typeof(int), null);
             }
 
             return null;

--- a/combit.ListLabel.SchemaAwareJsonDataProvider/JsonSchemaTable/JsonSchemaOnlyTableRow.cs
+++ b/combit.ListLabel.SchemaAwareJsonDataProvider/JsonSchemaTable/JsonSchemaOnlyTableRow.cs
@@ -33,17 +33,15 @@ namespace combit.Reporting.DataProviders
                 return new JsonTableColumn(columnName, typeof(string), LlConstants.NullValue);
             }
 
-            bool isNullable = !data.IsRequired;
-
             if (data.Type.HasFlag(JsonObjectType.Boolean))
             {
-                return new JsonTableColumn(columnName, isNullable ? typeof(bool?) : typeof(bool), null);
+                return new JsonTableColumn(columnName, typeof(bool), null);
             }
 
             //https://json-schema.org/draft/2020-12/json-schema-validation.html#rfc.section.7.3.1
             if (data.Type.HasFlag(JsonObjectType.String) && (data.Format == "date-time" || data.Format == "date" || data.Format == "time"))
             {
-                return new JsonTableColumn(columnName, isNullable ? typeof(DateTime?) : typeof(DateTime), null);
+                return new JsonTableColumn(columnName, typeof(DateTime), null);
             }
 
             if (data.Type.HasFlag(JsonObjectType.String))
@@ -55,12 +53,12 @@ namespace combit.Reporting.DataProviders
             //An arbitrary-precision, base-10 decimal number value, from the JSON "number" value
             if (data.Type.HasFlag(JsonObjectType.Number))
             {
-                return new JsonTableColumn(columnName, isNullable ? typeof(double?) : typeof(double), null);
+                return new JsonTableColumn(columnName, typeof(double), null);
             }
 
             if (data.Type.HasFlag(JsonObjectType.Integer))
             {
-                return new JsonTableColumn(columnName, isNullable ? typeof(int?) : typeof(int), null);
+                return new JsonTableColumn(columnName, typeof(int), null);
             }
 
             return null;

--- a/combit.ListLabel.SchemaAwareJsonDataProvider/SchemaAwareJsonDataProvider.cs
+++ b/combit.ListLabel.SchemaAwareJsonDataProvider/SchemaAwareJsonDataProvider.cs
@@ -1,6 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using NJsonSchema;
+using System.Collections.Generic;
 using System.IO;
-using NJsonSchema;
 
 namespace combit.Reporting.DataProviders
 {
@@ -69,7 +69,7 @@ namespace combit.Reporting.DataProviders
                     JsonData wrapper = new JsonData();
                     wrapper[ArrayValueName] = Data;
                     var schemaWrapper = new JsonSchema();
-                    schemaWrapper.Properties[ArrayValueName] = new JsonSchemaProperty { Item = _schema.Item, Type = _schema.Type };
+                    schemaWrapper.Properties[ArrayValueName] = new JsonSchemaProperty { Item = _schema.Item.ActualSchema, Type = _schema.Type };
                     BuildDomFromSchema(wrapper, RootTableName, schemaWrapper);
                 }
                 else
@@ -159,6 +159,6 @@ namespace combit.Reporting.DataProviders
                     BuildDomFromSchema(objectData, newTableName, schema.Properties[propertyName].Item);
                 }
             }
-        }        
+        }
     }
 }

--- a/combit.ListLabel.SchemaAwareJsonDataProvider/SchemaAwareJsonDataProvider.cs
+++ b/combit.ListLabel.SchemaAwareJsonDataProvider/SchemaAwareJsonDataProvider.cs
@@ -1,6 +1,7 @@
 ﻿using NJsonSchema;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace combit.Reporting.DataProviders
 {
@@ -22,6 +23,8 @@ namespace combit.Reporting.DataProviders
         /// The file- or url that points to a json schema definition (https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-00) which will be resolved by the provided <see cref="SchemaFileProvider"/>. If <see cref="SchemaFileProvider"/> is not set, the default <see cref="JsonDataProviderOptions.FileProvider"/> will be used.
         /// Properties must directly be provided under the properties-key (first single schema).
         /// AnyOf-Schema is currently not supported.
+        /// RootTableName will be set to the schema title.
+        /// ArrayValueName will be set to the array item name if data is an array.
         /// </summary>
         /// <seealso cref="SchemaFileProvider"/>
         public string Schema
@@ -35,6 +38,12 @@ namespace combit.Reporting.DataProviders
                 _schemaLocation = value;
                 var fileProvider = SchemaFileProvider ?? Options?.FileProvider ?? new NetworkFileProvider();
                 _schema = JsonSchema.FromJsonAsync(fileProvider.ReadAsString(_schemaLocation)).Result;
+
+                RootTableName = _schema.Title ?? RootTableName;
+                if (Data.IsArray)
+                {
+                    ArrayValueName = _schema.Definitions.FirstOrDefault().Key ?? ArrayValueName;
+                }
             }
         }
 

--- a/combit.ListLabel.SchemaAwareJsonDataProvider/SchemaAwareJsonDataProvider.cs
+++ b/combit.ListLabel.SchemaAwareJsonDataProvider/SchemaAwareJsonDataProvider.cs
@@ -42,7 +42,7 @@ namespace combit.Reporting.DataProviders
                 RootTableName = _schema.Title ?? RootTableName;
                 if (Data.IsArray)
                 {
-                    ArrayValueName = _schema.Definitions.FirstOrDefault().Key ?? ArrayValueName;
+                    ArrayValueName = _schema.Definitions?.FirstOrDefault().Key ?? ArrayValueName;
                 }
             }
         }


### PR DESCRIPTION
1. Use ActualSchema for array item, so all references are resolved.
2. Check for nullable properties.
3. Use the schema information to set RootTableName and ArrayValueName.